### PR TITLE
use repeat_interleave for input_features in _prepare_logprob_inputs

### DIFF
--- a/west/trainer/grpo_trainer.py
+++ b/west/trainer/grpo_trainer.py
@@ -177,7 +177,7 @@ class GRPOTrainer(Trainer):
         # Expand masks for num_generations
         prompt_mask = inputs["attention_mask"].repeat_interleave(self.num_generations, dim=0)
         attention_mask = torch.cat([prompt_mask, generated_mask], dim=1)
-        input_features = inputs["input_features"].repeat(self.num_generations, 1, 1)
+        input_features = inputs["input_features"].repeat_interleave(self.num_generations, dim=0)
         feature_mask = inputs["feature_attention_mask"].repeat_interleave(self.num_generations, dim=0)
 
         return {


### PR DESCRIPTION
## Problem

When `batch_size > 1`, `input_features` is misaligned with generated sequences in `_prepare_logprob_inputs`. All other tensors (`input_ids`, `attention_mask`, `feature_attention_mask`) use `repeat_interleave` which produces the order `[s0, s0, s0, s1, s1, s1, ...]`, but `input_features` used `.repeat(num_generations, 1, 1)` which produces `[s0, s1, s0, s1, s0, s1, ...]`. This causes audio features to be paired with the wrong generated sequences, making log probability computation incorrect and corrupting GRPO gradient updates.

## Root Cause

`west/trainer/grpo_trainer.py` line 180:
```python
# Wrong: mismatched ordering with all other tensors in the same function
input_features = inputs["input_features"].repeat(self.num_generations, 1, 1)
```

## Fix

```python
input_features = inputs["input_features"].repeat_interleave(self.num_generations, dim=0)
```

This makes `input_features` consistent with every other tensor expanded in the same function.

## Testing

The bug is silent when `per_device_train_batch_size=1` (the default), but corrupts training for any larger batch size.