### PR TITLE
fix mel_spectrogram cache keys to include all config parameters

### DIFF
--- a/west/utils/audio.py
+++ b/west/utils/audio.py
@@ -60,15 +60,17 @@ def mel_spectrogram(y,
     #     print("max value is ", torch.max(y))
 
     global mel_basis, hann_window  # noqa
-    if f"{str(fmax)}_{str(y.device)}" not in mel_basis:
+    mel_key = f"{n_fft}_{num_mels}_{sampling_rate}_{fmin}_{fmax}_{str(y.device)}"
+    win_key = f"{win_size}_{str(y.device)}"
+    if mel_key not in mel_basis:
         mel = librosa_mel_fn(sr=sampling_rate,
                              n_fft=n_fft,
                              n_mels=num_mels,
                              fmin=fmin,
                              fmax=fmax)
-        mel_basis[str(fmax) + "_" +
-                  str(y.device)] = torch.from_numpy(mel).float().to(y.device)
-        hann_window[str(y.device)] = torch.hann_window(win_size).to(y.device)
+        mel_basis[mel_key] = torch.from_numpy(mel).float().to(y.device)
+    if win_key not in hann_window:
+        hann_window[win_key] = torch.hann_window(win_size).to(y.device)
 
     y = torch.nn.functional.pad(y.unsqueeze(1), (int(
         (n_fft - hop_size) / 2), int((n_fft - hop_size) / 2)),
@@ -81,7 +83,7 @@ def mel_spectrogram(y,
             n_fft,
             hop_length=hop_size,
             win_length=win_size,
-            window=hann_window[str(y.device)],
+            window=hann_window[win_key],
             center=center,
             pad_mode="reflect",
             normalized=False,
@@ -91,7 +93,7 @@ def mel_spectrogram(y,
 
     spec = torch.sqrt(spec.pow(2).sum(-1) + (1e-9))
 
-    spec = torch.matmul(mel_basis[str(fmax) + "_" + str(y.device)], spec)
+    spec = torch.matmul(mel_basis[mel_key], spec)
     spec = spectral_normalize_torch(spec)
 
     return spec


### PR DESCRIPTION
The mel_basis and hann_window caches in mel_spectrogram use incomplete keys:

- mel_basis only keys on fmax + device, ignoring n_fft, num_mels, sampling_rate, fmin
- hann_window only keys on device, ignoring win_size

Two concrete failure modes:

1. A call with the same fmax but different num_mels silently returns the wrong mel filterbank.
2. A call with a different win_size hits a cached window of the wrong length and crashes in torch.stft with "Expected a window of size N, but got M".

There's also a coupling bug: both caches were populated under a single mel_basis check, so changing fmax between calls could silently overwrite hann_window with a different win_size.

Fix: use fully qualified independent keys for each cache so different configurations don't interfere with each other.